### PR TITLE
Use unique hostnames

### DIFF
--- a/inventory/clints.py
+++ b/inventory/clints.py
@@ -47,6 +47,10 @@ DOCUMENTATION = '''
         regions:
           description: A list of regions in which to describe EC2 instances. By default this is all regions except us-gov-west-1
               and cn-north-1.
+        batch:
+          description: The maximum number of scale labs being combined to provide unique suffixes for the hostnames.
+          default: 1000
+          type: int
 '''
 
 EXAMPLES = '''
@@ -212,6 +216,8 @@ class InventoryModule(BaseInventoryPlugin):
         self.inventory.add_group('clint_ssh')
         self.inventory.add_child('all', 'clint_ssh')
 
+        unique_hostnames = set()
+
         for ec2, ecs, region in self._boto3_conn(regions):
             container_host_ips = {}
             use_clusters = ecs.describe_clusters(
@@ -233,6 +239,12 @@ class InventoryModule(BaseInventoryPlugin):
                             inst_dns = ec2.describe_instances(InstanceIds=[instance_id])['Reservations'][0]['Instances'][0]['PublicDnsName']
                             container_host_ips[task['containerInstanceArn']] = inst_dns
                         hostname = task['taskArn'].split('/')[-1].replace('-', '')
+                        for unique_suffix in range(0, self.get_option('batch')):
+                            if hostname not in unique_hostnames:
+                                unique_hostnames.update(hostname)
+                                break
+                            else:
+                                hostname = hostname + suffix
                         self.inventory.add_host(hostname, group=cluster_name.replace('-', '_'))
                         if 'ssh-target' in task['group']:
                             self.inventory.add_host(hostname, group='clint_ssh')

--- a/inventory/clints.py
+++ b/inventory/clints.py
@@ -239,7 +239,7 @@ class InventoryModule(BaseInventoryPlugin):
                         for unique_suffix in range(0, 1000):
                             if "{0}{1}".format(hostname, unique_suffix) not in unique_hostnames:
                                 hostname = "{0}{1}".format(hostname, unique_suffix)
-                                unique_hostnames.update(hostname)
+                                unique_hostnames.update([hostname])
                                 break
                         self.inventory.add_host(hostname, group=cluster_name.replace('-', '_'))
                         if 'ssh-target' in task['group']:

--- a/inventory/clints.py
+++ b/inventory/clints.py
@@ -45,8 +45,17 @@ DOCUMENTATION = '''
               - name: AWS_SESSION_TOKEN
               - name: EC2_SECURITY_TOKEN
         regions:
-          description: A list of regions in which to describe EC2 instances. By default this is all regions except us-gov-west-1
-              and cn-north-1.
+          description: A list of regions in which to describe EC2 instances.
+              By default this is all valid ECS regions (us-east-1, us-east-2, us-west-1, us-west-2, sa-east-1,
+              ca-central-1) except us-gov-west-1 and us-gov-east-1.
+          type: list
+          default:
+            - us-east-1
+            - us-east-2
+            - us-west-1
+            - us-west-2
+            - sa-east-1
+            - ca-central-1
 '''
 
 EXAMPLES = '''
@@ -171,7 +180,7 @@ class InventoryModule(BaseInventoryPlugin):
                     a list of possible hostnames in order of preference
                     a boolean to indicate whether to fail on permission errors
         '''
-        options = {'regions': {'type_to_be': list, 'value': config_data.get('regions', [])}}
+        options = {'regions': {'type_to_be': list, 'value': self.get_option('regions')}}
 
         # validate the options
         for name in options:


### PR DESCRIPTION
When running against a large inventory with separate scale labs (due to capacity constraints) there will be a large overlap on the hostnames. I think it's unnecessary to expose the `batch` option, so I might remove that.