### PR TITLE
Make ASG MaxSize be calculated based on cluster_size

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -26,7 +26,7 @@
         #InstanceType: c5.4xlarge
         InstanceType: '{{ instance_type }}'
         SpotBidPrice: 0.20
-        MaxSize: 8
+        MaxSize: '{{ ((cluster_size|int * 1.5)) | int }}'
         # 31144 is amount of container memory capacity on a c5.4xlarge
         DesiredCapacity: '{{ cluster_size }}'
         MinSize: 0


### PR DESCRIPTION
Very large clusters (ex; `desired_targets` of 10,000) require an ASG MaxSize greater than 8.  Make this value be generated based on the `cluster_size`.